### PR TITLE
Better Silverfish Room

### DIFF
--- a/rooms/silverfish.rb
+++ b/rooms/silverfish.rb
@@ -1,53 +1,288 @@
 class SilverfishRoom
-  ROCK_STATES = {
-    "diamond"     => "There is a gleaming patch of crystal ahead",
-    "gold"        => "There is shiny, metallic rock ahead",
-    "iron"        => "There is some red-stained grey rock ahead",
-    "cobblestone" => "There is plain, gray rock ahead.",
-  }
-  SILVERFISH_CHANCE = 0.5
+  MAP_LENGTH = 9
+  MAP_WIDTH = 9
 
   def initialize
     @score = 0
+    @pickaxe = false
+    @map = MineMap.new(MAP_WIDTH, MAP_LENGTH)
   end
 
   def play
     describe
-    mine
+
+    while not @map.player_escaped?
+      rock = @map.get_rock_ahead
+
+      if @pickaxe
+        @map.print_map
+
+        if rock
+          puts rock.description
+        else
+          puts "There is nothing in front of you"
+        end
+      end
+
+      choice = Game.get_input
+
+      if choice.include? "mine"
+        if @pickaxe
+          @score += @map.mine
+          sleep 1
+        else
+          puts "With what, your hands!?\n\n"
+        end
+      elsif choice.include? "left"
+        @map.turn_left
+      elsif choice.include? "right"
+        @map.turn_right
+      elsif choice.include? "turn around"
+        @map.turn_around
+      elsif choice.include? "move"
+        if rock
+          puts "There's a rock there!"
+        else
+          @map.move_forward
+        end
+      elsif choice.include? "search"
+        if @pickaxe
+          puts "You do not find anything new\n\n"
+        else
+          puts "You have discovered a pickaxe!\n\n"
+          sleep 1
+          @pickaxe = true
+        end
+      elsif choice.include? "door"
+        puts "The door is locked\n\n"
+      else
+        puts "Sorry, I have no idea what you're talking about. Maybe try rephrasing?\n\n"
+      end
+
+      Game.clear_screen if @pickaxe
+    end
   end
 
+  private #####################################################################
+
   def describe
-    Game.clear_screen
     puts "You are standing in a damp room, somewhere underground."
-    puts "The room appears to be hewn from the subterranian rock."
     puts "Around you, water flows in small streams down the walls,"
-    puts "and the sound of dripping is almost deafening. Adjacent"
-    puts "to the doorway in which you stand, there is a pickaxe.\n"
+    puts "and the sound of dripping is almost deafening. The room"
+    puts "appears to be hewn from the subterranian rock. Suddenly,"
+    puts "the door slams shut behind you.\n\n"
+  end
+end
+
+class MineMap
+  DIRECTIONS = {
+    north: 0,
+    east:  1,
+    south: 2,
+    west:  3
+  }
+
+  def initialize(width, length)
+    @width = width
+    @length = length
+    @map = generate_map
+    @coords = Array.new(2)
+    @direction = DIRECTIONS[:north]
+    move_player(width / 2, length - 1)
+  end
+
+  def move_player(x, y)
+    @map[x][y] = nil
+    @coords = [x, y]
   end
 
   def mine
-    while true
-      state = weighted_sample(ROCK_STATES.keys)
+    rock = get_rock_ahead
 
-      puts
-      puts ROCK_STATES[state]
-      print "Mine? "
+    if rock.nil?
+      puts "There's nothing there to mine, dummy!"
+      return 0
+    end
 
-      if not yes?
-        puts "You are done mining."
-        puts
-        puts "Your score is: #{@score}"
-        return
-      elsif silverfish?(state)
-        Game.you_died "A silverfish attacks you, and you die."
-        puts "Your score was: #{@score}"
-        return
-      else
-        puts "You have mined some #{state}"
-        @score += ROCK_STATES.keys.index(state)
+    if rock.silverfish?
+      puts "Your score was: #{@score}"
+      Game.you_died "A silverfish attacks you, and you die."
+    end
+
+    puts "You have mined some #{rock.name}\n\n"
+    remove_rock_ahead
+    move_forward
+    return rock.score
+  end
+
+  def remove_rock_ahead
+    remove_rock get_coords_ahead
+  end
+
+  def get_rock_ahead
+    rock_coords = get_coords_ahead
+    @map[rock_coords[0]][rock_coords[1]] unless out_of_bounds? rock_coords
+  end
+
+  def move_forward
+    new_coords = get_coords_ahead
+    @coords = new_coords
+  end
+
+  def player_escaped?
+    @coords[0] == 0 ||
+      @coords[1] == 0 ||
+      @coords[0] == @length - 1
+  end
+
+  def turn_left
+    @direction -= 1
+    @direction = 3 if @direction == -1
+  end
+
+  def turn_right
+    @direction += 1
+    @direction = 0 if @direction == 4
+  end
+
+  def turn_around
+    @direction += 2
+    @direction = @direction - 4 if @direction > 3
+  end
+
+  def face(direction)
+    @direction = direction
+  end
+
+  def print_map
+    (0...@length).each do |y|
+      (0...@width).each do |x|
+        print "+"
+
+        if @map[x][y].nil? and !get_rock_ahead_in_direction [x, y], DIRECTIONS[:north]
+          print "   "
+        else
+          print "---"
+        end
       end
+
+      puts "+"
+
+      (0...@width).each do |x|
+        if @map[x][y].nil? and !get_rock_ahead_in_direction [x, y], DIRECTIONS[:west]
+          print " "
+        else
+          print "|"
+        end
+        print " "
+        if @map[x][y] and [x, y] == get_coords_ahead
+          print @map[x][y].abbr
+        elsif [x, y] == @coords
+          print player_symbol
+        else
+          print " "
+        end
+        print " "
+      end
+
+      puts "|"
+    end
+
+    puts Array.new(@width + 1) { "+" }.join("---")
+  end
+
+  private #####################################################################
+
+  def out_of_bounds? coords
+    @coords[0] < 0 ||
+      @coords[1] < 0 ||
+      @coords[0] >= @width ||
+      @coords[1] >= @length
+  end
+
+  def remove_rock(coords)
+    @map[coords[0]][coords[1]] = nil
+  end
+
+  def player_symbol
+    case @direction
+    when DIRECTIONS[:north]
+      "^"
+    when DIRECTIONS[:east]
+      ">"
+    when DIRECTIONS[:south]
+      "v"
+    when DIRECTIONS[:west]
+      "<"
     end
   end
+
+  def get_coords_ahead
+    get_coords_ahead_in_direction @coords, @direction
+  end
+
+  def get_coords_ahead_in_direction coords, direction
+    case direction
+    when DIRECTIONS[:north]
+      [coords[0], coords[1] - 1]
+    when DIRECTIONS[:east]
+      [coords[0] + 1, coords[1]]
+    when DIRECTIONS[:south]
+      [coords[0], coords[1] + 1]
+    when DIRECTIONS[:west]
+      [coords[0] - 1, coords[1]]
+    end
+  end
+
+  def get_rock_ahead_in_direction coords, direction
+    coords = get_coords_ahead_in_direction coords, direction
+    return nil if out_of_bounds? coords
+    @map[coords[0]][coords[1]]
+  end
+
+  def generate_map
+    map = Array.new(@width) { Array.new(@length) } # X, Y
+    (0...@width).each do |x|
+      (0...@length).each do |y|
+        map[x][y] = Rock.new
+      end
+    end
+    return map
+  end
+end
+
+class Rock
+  ROCK_STATES = {
+    "diamond" =>      "There is a gleaming patch of crystal ahead",
+    "gold" =>         "There is shiny, metallic rock ahead",
+    "iron" =>         "There is some red-stained grey rock ahead",
+    "cobblestone" =>  "There is plain, gray rock ahead.",
+  }
+  SILVERFISH_CHANCE = 0.5
+
+  attr_reader :name
+
+  def initialize
+    @name = weighted_sample ROCK_STATES.keys
+  end
+
+  def silverfish?
+    @name == "cobblestone" and rand > SILVERFISH_CHANCE
+  end
+
+  def description
+    ROCK_STATES[@name]
+  end
+
+  def score
+    ROCK_STATES.keys.index(@name)
+  end
+
+  def abbr
+    @name[0]
+  end
+
+  private #####################################################################
 
   def weighted_sample arr
     n = arr.length
@@ -57,13 +292,5 @@ class SilverfishRoom
     (1..n).each do |i|
       return arr[i - 1] if r < ((2 ** i) - 1).to_f / total
     end
-  end
-
-  def silverfish? state
-    state == "cobblestone" and rand > SILVERFISH_CHANCE
-  end
-
-  def yes?
-    return ["y", "yes", "yeah", "sure"].include? gets.chomp.downcase
   end
 end

--- a/rooms/silverfish.rb
+++ b/rooms/silverfish.rb
@@ -12,11 +12,10 @@ class SilverfishRoom
     describe
 
     while not @map.player_escaped?
-      rock = @map.get_rock_ahead
-
       if @pickaxe
         @map.print_map
 
+        rock = @map.get_rock_ahead
         if rock
           puts rock.description
         else
@@ -25,41 +24,56 @@ class SilverfishRoom
       end
 
       choice = Game.get_input
-
-      if choice.include? "mine"
-        if @pickaxe
-          @score += @map.mine
-          sleep 1
-        else
-          puts "With what, your hands!?\n\n"
-        end
-      elsif choice.include? "left"
-        @map.turn_left
-      elsif choice.include? "right"
-        @map.turn_right
-      elsif choice.include? "turn around"
-        @map.turn_around
-      elsif choice.include? "move"
-        if rock
-          puts "There's a rock there!"
-        else
-          @map.move_forward
-        end
-      elsif choice.include? "search"
-        if @pickaxe
-          puts "You do not find anything new\n\n"
-        else
-          puts "You have discovered a pickaxe!\n\n"
-          sleep 1
-          @pickaxe = true
-        end
-      elsif choice.include? "door"
-        puts "The door is locked\n\n"
-      else
-        puts "Sorry, I have no idea what you're talking about. Maybe try rephrasing?\n\n"
-      end
-
       Game.clear_screen if @pickaxe
+      act choice, rock
+      puts
+    end
+  end
+
+  def act choice, rock
+    if choice.include? "mine"
+      if @pickaxe
+        if !rock
+          puts "There's nothing there to mine, dummy!"
+        elsif rock.silverfish?
+          puts "Your score was: #{@score}"
+          Game.you_died "A silverfish attacks you, and you die."
+        else
+          @score += @map.mine
+        end
+      else
+        puts "With what, your hands!?"
+      end
+    elsif choice.include? "left"
+      @map.turn_left
+      puts
+    elsif choice.include? "right"
+      @map.turn_right
+      puts
+    elsif choice.include? "turn around"
+      @map.turn_around
+      puts
+    elsif choice.include? "move"
+      if @map.get_rock_ahead
+        puts "There's a rock there!"
+      else
+        @map.move_forward
+        puts
+      end
+    elsif choice.include? "search"
+      if @pickaxe
+        puts "You do not find anything new"
+      else
+        puts "You have discovered a pickaxe!"
+        @pickaxe = true
+        sleep 1
+        Game.clear_screen
+        puts
+      end
+    elsif choice.include? "door"
+      puts "The door is locked"
+    else
+      puts "Sorry, I have no idea what you're talking about. Maybe try rephrasing?"
     end
   end
 
@@ -99,19 +113,10 @@ class MineMap
   def mine
     rock = get_rock_ahead
 
-    if rock.nil?
-      puts "There's nothing there to mine, dummy!"
-      return 0
-    end
-
-    if rock.silverfish?
-      puts "Your score was: #{@score}"
-      Game.you_died "A silverfish attacks you, and you die."
-    end
-
-    puts "You have mined some #{rock.name}\n\n"
+    puts "You have mined some #{rock.name}"
     remove_rock_ahead
     move_forward
+
     return rock.score
   end
 

--- a/rooms/silverfish.rb
+++ b/rooms/silverfish.rb
@@ -1,30 +1,68 @@
 class SilverfishRoom
+  def initialize
+    @done
+  end
+
+  def play
+    while !@done
+      describe
+      act Game.get_input
+    end
+  end
+
+  private #####################################################################
+
+  def act choice
+    if choice.include? "mine"
+      puts "With what, your hands!?"
+    elsif choice.include? "search"
+      puts "You have discovered a pickaxe!"
+      @done = true
+      sleep 1
+
+      MineRoom.new.play
+    elsif choice.include? "door"
+      puts "The door is locked."
+    else
+      puts "Sorry, I have no idea what you're talking about. Maybe try rephrasing?"
+    end
+    puts
+  end
+
+  def describe
+    puts "You are standing in a damp room, somewhere underground."
+    puts "Around you, water flows in small streams down the walls"
+    puts "and the sound of dripping is almost deafening. The room"
+    puts "appears to be hewn from the subterranian rock. As you"
+    puts "look around, you notice that the walls seem to have some"
+    puts "precious stones in them. Suddenly,the door slams shut"
+    puts "behind you.\n\n"
+  end
+end
+
+class MineRoom
   MAP_LENGTH = 9
   MAP_WIDTH = 9
 
   def initialize
     @score = 0
-    @pickaxe = false
     @map = MineMap.new(MAP_WIDTH, MAP_LENGTH)
   end
 
   def play
-    describe
+    Game.clear_screen
+    puts "\n\n"
 
     while not @map.player_escaped?
-      if @pickaxe
-        @map.print_map
+      @map.print_map
 
-        rock = @map.get_rock_ahead
-        if rock
-          puts rock.description
-        else
-          puts "There is nothing in front of you"
-        end
-      end
+      rock = @map.get_rock_ahead
+      puts rock ? rock.description : ""
 
       choice = Game.get_input
-      Game.clear_screen if @pickaxe
+
+      Game.clear_screen
+
       act choice, rock
       puts
     end
@@ -34,18 +72,16 @@ class SilverfishRoom
 
   def act choice, rock
     if choice.include? "mine"
-      if @pickaxe
-        if !rock
-          puts "There's nothing there to mine, dummy!"
-        elsif rock.silverfish?
-          puts "Your score was: #{@score}"
-          Game.you_died "A silverfish attacks you, and you die."
-        else
-          @score += @map.mine
-        end
+      if !rock
+        puts "There's nothing there to mine, dummy!"
+      elsif rock.silverfish?
+        puts "Your score was: #{@score}"
+        Game.you_died "A silverfish attacks you, and you die."
       else
-        puts "With what, your hands!?"
+        @score += @map.mine
       end
+    elsif choice.include? "search"
+      puts "You do not find anything new"
     elsif choice.include? "left"
       @map.turn_left
       puts
@@ -64,29 +100,11 @@ class SilverfishRoom
         @map.move_forward
         puts
       end
-    elsif choice.include? "search"
-      if @pickaxe
-        puts "You do not find anything new"
-      else
-        puts "You have discovered a pickaxe!"
-        @pickaxe = true
-        sleep 1
-        Game.clear_screen
-        puts
-      end
     elsif choice.include? "door"
       puts "The door is locked"
     else
       puts "Sorry, I have no idea what you're talking about. Maybe try rephrasing?"
     end
-  end
-
-  def describe
-    puts "You are standing in a damp room, somewhere underground."
-    puts "Around you, water flows in small streams down the walls,"
-    puts "and the sound of dripping is almost deafening. The room"
-    puts "appears to be hewn from the subterranian rock. Suddenly,"
-    puts "the door slams shut behind you.\n\n"
   end
 end
 


### PR DESCRIPTION
These changes currently pull the behavior of the Silverfish room more into line with how the other rooms behave. However, this room is not usually winnable in its current form, so it's still a work in progress.

**UPDATE**

Prepare yourself! The Silverfish room is now navigable. You can navigate around using "left", "right", "turn around", "move", and "mine!" The field is not necessarily winnable.

**UPDATE**

The map does not jump around anymore between turns, and you can't disappear into the south wall anymore. All that remains pending is a refactor.

**UPDATE**

I split the `SilverfishRoom` class into two classes, `SilverfishRoom` and `MineRoom`. There are still some monolithic classes (`MineMap`, for instance), but I am satisfied with this PR's current state.
